### PR TITLE
Fix .belongs_to_static to work with ActiveSupport 3

### DIFF
--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -52,7 +52,7 @@ module StaticAssociation
       self.send(:define_method, name) do
         begin
           foreign_key = self.send("#{name}_id")
-          name.to_s.classify.constantize.find(foreign_key) if foreign_key
+          name.to_s.camelize.constantize.find(foreign_key) if foreign_key
         rescue RecordNotFound
           nil
         end

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -84,4 +84,22 @@ describe StaticAssociation do
       end
     end
   end
+
+  describe ".belongs_to_static" do
+    class AssociationClass
+      attr_accessor :dummy_class_id
+      
+      extend StaticAssociation::AssociationHelpers
+      belongs_to_static :dummy_class
+    end
+
+    let(:associated_class) { AssociationClass.new }
+
+    it "creates reader method that uses the correct singularized class when finding static association" do
+      expect {
+        DummyClass.should_receive(:find)
+      }
+      associated_class.dummy_class
+    end
+  end
 end


### PR DESCRIPTION
ActiveSupport 3 String#classify does not return the correct singular class name for strings ending in 'ss'.

Examples:
- business => Busines
- dummy_class => DummyClas

Use String#camelize to resolve this.

This is not an issue in ActiveSupport 4 as it does not change strings ending in 'ss'.
