### PR TITLE
Add support for class name option

### DIFF
--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -48,11 +48,13 @@ module StaticAssociation
   end
 
   module AssociationHelpers
-    def belongs_to_static(name)
+    def belongs_to_static(name, opts = {})
+      class_name = opts.fetch(:class_name, name.to_s.camelize)
+
       self.send(:define_method, name) do
         begin
           foreign_key = self.send("#{name}_id")
-          name.to_s.camelize.constantize.find(foreign_key) if foreign_key
+          class_name.constantize.find(foreign_key) if foreign_key
         rescue RecordNotFound
           nil
         end

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -88,9 +88,11 @@ describe StaticAssociation do
   describe ".belongs_to_static" do
     class AssociationClass
       attr_accessor :dummy_class_id
+      attr_accessor :dodo_class_id
 
       extend StaticAssociation::AssociationHelpers
       belongs_to_static :dummy_class
+      belongs_to_static :dodo_class, class_name: 'DummyClass'
     end
 
     let(:associated_class) { AssociationClass.new }
@@ -100,6 +102,13 @@ describe StaticAssociation do
         DummyClass.should_receive(:find)
       }
       associated_class.dummy_class
+    end
+
+    it "creates a different reader method that uses the specified class when finding static asssociation" do
+      expect {
+        DummyClass.should_receive(:find)
+      }
+      associated_class.dodo_class
     end
   end
 end


### PR DESCRIPTION
So you can use the same model for multiple associations. For the situation where you might have, say, a number of fields on a model that refer to the same thing, and you don't want _n_ classes with identical records to implement it.
