### PR TITLE
Remove OrderedHash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/bundle

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -25,7 +25,7 @@ module StaticAssociation
     delegate :each, to: :all
 
     def index
-      @index ||= ActiveSupport::OrderedHash.new
+      @index ||= {} 
     end
 
     def all

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -1,6 +1,5 @@
 require 'static_association/version'
 require 'active_support/concern'
-require 'active_support/ordered_hash'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/string/inflections'


### PR DESCRIPTION
It's unnecessary - ids are explicit, and in any case hashes maintain order since 1.9 anyway.