### PR TITLE
Add a `.where` class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ end
 
 Calling `record` will allow you to create an instance of this static model, a unique id is mandatory. The newly created object is yielded to the passed block.
 
-The `Day` class will gain an `all` and `find` method.
+The `Day` class will gain `.all`, `.find` and `.where` methods.
+
+- The `.all` method returns all the static records defined in the class
+- The `.find` method accepts a single id and returns the matching record. If the
+  record does not exist, a `RecordNotFound` error is raised.
+- The `.where` method accepts an array of ids and returns all records with
+  matching ids.
 
 ### Associations
 

--- a/lib/static_association.rb
+++ b/lib/static_association.rb
@@ -24,7 +24,7 @@ module StaticAssociation
     delegate :each, to: :all
 
     def index
-      @index ||= {} 
+      @index ||= {}
     end
 
     def all
@@ -46,6 +46,10 @@ module StaticAssociation
       record = self.new(id)
       record.instance_exec(record, &block) if block_given?
       index[id] = record
+    end
+
+    def where(ids)
+      ids.map { |id| find_by_id(id) }.compact
     end
   end
 

--- a/spec/static_association_spec.rb
+++ b/spec/static_association_spec.rb
@@ -75,13 +75,9 @@ describe StaticAssociation do
   end
 
   describe "finders" do
-    before do
-      DummyClass.record id: 1 do
-        self.name = 'asdf'
-      end
-    end
-
     describe ".find" do
+      before { create_dummy_class }
+
       context "record exists" do
         subject { DummyClass.find(1) }
 
@@ -99,6 +95,8 @@ describe StaticAssociation do
     end
 
     describe ".find_by_id" do
+      before { create_dummy_class }
+
       context "record exists" do
         subject { DummyClass.find_by_id(1) }
 
@@ -109,6 +107,18 @@ describe StaticAssociation do
       context "record does not exist" do
         subject { DummyClass.find_by_id(:not_in_the_index) }
         it { should be_nil }
+      end
+    end
+
+    describe ".where" do
+      it "returns records that exist" do
+        record_1 = DummyClass.record(id: 1) { self.name = "First" }
+        record_2 = DummyClass.record(id: 2) { self.name = "Second" }
+        record_3 = DummyClass.record(id: 3) { self.name = "Third" }
+
+        results = DummyClass.where([1, 3])
+
+        expect(results).to eq([record_1, record_3])
       end
     end
   end
@@ -137,6 +147,12 @@ describe StaticAssociation do
         DummyClass.should_receive(:find)
       }
       associated_class.dodo_class
+    end
+  end
+
+  def create_dummy_class
+    DummyClass.record id: 1 do
+      self.name = 'asdf'
     end
   end
 end


### PR DESCRIPTION
This implements a `.where` method for retrieving an array of static records. The
method accepts an array of ids and returns an array of records. Unlike the
`.find` record, if a record does not exist for a given id, an error is **not**
raised.